### PR TITLE
fix typo in or-glpk export list: gl-prob -> glp-prob

### DIFF
--- a/subsystem/or-glpk/package.lisp
+++ b/subsystem/or-glpk/package.lisp
@@ -21,7 +21,7 @@
 (defpackage #:or-glpk
   (:use #:cl)
   (:export 
-  	#:gl-prob
+  	#:glp-prob
   	#:name
   	#:with-problem
   	#:write-cplex-lp


### PR DESCRIPTION
It seems `gl-prob` is not defined anywhere, so I assume this was a typo and the intention was to export the reader for `glp-prob`?

No real testing done, other than to verify that after this change I can get the foreign pointer by calling `or-glpk:glp-prob` in sbcl:

```lisp
CL-USER> (or-glpk:with-problem (p :name "some-problem") (or-glpk:glp-prob p))
#.(SB-SYS:INT-SAP #X7FFFE8002D00)
```